### PR TITLE
.github: Move away from actions-rs

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,11 +27,10 @@ jobs:
         run: sudo apt install -y musl-tools
 
       - name: Install Rust toolchain (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          override: true
 
       - name: Build (default features)
         run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings -D clippy::undocumented_unsafe_blocks

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
           - x86_64-unknown-linux-musl
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -5,7 +5,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.x
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/fuzz-build.yaml
+++ b/.github/workflows/fuzz-build.yaml
@@ -14,7 +14,7 @@ jobs:
           - x86_64-unknown-linux-gnu
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Rust toolchain (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/hadolint.yaml
+++ b/.github/workflows/hadolint.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@master

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     container: openapitools/openapi-generator-cli
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Validate OpenAPI
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -34,7 +34,7 @@ jobs:
             experimental: true
     steps:
       - name: Code checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -133,6 +133,6 @@ jobs:
     name: Typos / Spellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Executes "typos ."
       - uses: crate-ci/typos@v1.16.11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,33 +14,25 @@ jobs:
       - name: Create release directory
         run: rsync -rv --exclude=.git . ../cloud-hypervisor-${{ github.event.ref }}
       - name: Install Rust toolchain (x86_64-unknown-linux-gnu)
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: "1.70"
           target: x86_64-unknown-linux-gnu
       - name: Install Rust toolchain (x86_64-unknown-linux-musl)
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: "1.70"
           target: x86_64-unknown-linux-musl
       - name: Build
-        uses: actions-rs/cargo@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: "1.70"
-          command: build
-          args: --all --release --features mshv --target=x86_64-unknown-linux-gnu
+      - run: cargo build --release --features mshv --target=x86_64-unknown-linux-gnu
       - name: Static Build
-        uses: actions-rs/cargo@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: "1.70"
-          command: build
-          args: --all --release --features mshv --target=x86_64-unknown-linux-musl
-      - name: Install Rust toolchain (aarch64-unknown-linux-musl)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: "1.70"
-          target: aarch64-unknown-linux-musl
-          override: true
+      - run: cargo build --release --features mshv --target=x86_64-unknown-linux-musl
       - name: Create Release
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: create_release
@@ -97,15 +89,14 @@ jobs:
           asset_name: ch-remote-static
           asset_content_type: application/octet-stream
       - name: Clean build tree ahead of cross build
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+        run: cargo clean
       - name: Static Build (AArch64)
-        uses: actions-rs/cargo@v1
+        uses: houseabsolute/actions-rust-cross@v0
         with:
-          use-cross: true
+          toolchain: "1.70"
+          target: aarch64-unknown-linux-musl
           command: build
-          args: --all --release --target=aarch64-unknown-linux-musl
+          args: "--all --release --target=aarch64-unknown-linux-musl"
       - name: Upload static AArch64 cloud-hypervisor
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         id: upload-release-static-aarch64-cloud-hypervisor

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install musl-gcc
         run: sudo apt install -y musl-tools
       - name: Create release directory

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -49,7 +49,7 @@ qemu-system-x86_64 \
 	-m 4G \
 	-bios ./$OVMF_DIR/OVMF_CODE.fd \
 	-cdrom ./$WIN_ISO_FILE \
-	-drive file=./$VIRTIO_ISO_FILE,index=0,media=cdrom
+	-drive file=./$VIRTIO_ISO_FILE,index=0,media=cdrom \
 	-drive if=none,id=root,file=./$IMG_FILE \
 	-device virtio-blk-pci,drive=root,disable-legacy=on \
 	-device virtio-net-pci,netdev=mynet0,disable-legacy=on \

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -14,8 +14,8 @@ tdx = []
 [dependencies]
 anyhow = "1.0.75"
 byteorder = "1.4.3"
-igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main" , package = "igvm_defs", optional  = true }
-igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main" , package = "igvm", optional  = true }
+igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm_defs", optional  = true }
+igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm", optional  = true }
 libc = "0.2.147"
 log = "0.4.20"
 kvm-ioctls = { version = "0.13.0", optional = true }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -35,8 +35,8 @@ gdbstub = { version = "0.7.0", optional = true }
 gdbstub_arch = { version = "0.3.0", optional = true }
 hex = { version = "0.4.3", optional = true }
 hypervisor = { path = "../hypervisor" }
-igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main" , package = "igvm_defs", optional  = true }
-igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main" , package = "igvm", optional  = true }
+igvm_defs = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm_defs", optional  = true }
+igvm_parser = { git = "https://github.com/microsoft/igvm", branch = "main", package = "igvm", optional  = true }
 libc = "0.2.147"
 linux-loader = { version = "0.10.0", features = ["elf", "bzimage", "pe"] }
 log = "0.4.20"

--- a/vmm/src/igvm/igvm_loader.rs
+++ b/vmm/src/igvm/igvm_loader.rs
@@ -309,10 +309,10 @@ pub fn load_igvm(
             } => {
                 loaded_info.snp_id_block.compatibility_mask = *compatibility_mask;
                 loaded_info.snp_id_block.author_key_enabled = *author_key_enabled;
-                loaded_info.snp_id_block.reserved[..3].copy_from_slice(reserved);
-                loaded_info.snp_id_block.ld[..48].copy_from_slice(ld);
-                loaded_info.snp_id_block.family_id[..16].copy_from_slice(family_id);
-                loaded_info.snp_id_block.image_id[..16].copy_from_slice(image_id);
+                loaded_info.snp_id_block.reserved = *reserved;
+                loaded_info.snp_id_block.ld = *ld;
+                loaded_info.snp_id_block.family_id = *family_id;
+                loaded_info.snp_id_block.image_id = *image_id;
                 loaded_info.snp_id_block.version = *version;
                 loaded_info.snp_id_block.guest_svn = *guest_svn;
                 loaded_info.snp_id_block.id_key_algorithm = *id_key_algorithm;


### PR DESCRIPTION
Since actions-rs is deprecated so we need to move away from it and use alternatives which are better maintained by the community. There are two available alternatives:

1. https://github.com/actions-rust-lang/setup-rust-toolchain
2. https://github.com/dtolnay/rust-toolchain

I went on with setup-rust-toolchain for the following reasons:

- It is inspired by dtolnay/rust-toolchain and contains the missing features from it.
- It also has readily available cargo audit actions which is required by CloudHypervisor for one of it step.